### PR TITLE
Change to promise-style '.then' and '.catch' api

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -216,7 +216,7 @@ Router.prototype.findSingleAssociatedModel = function(modelName, identifier, ass
       if (err) {
         callback(err, null)
       } else {
-        dao[association.accessors.get]().success(function(associatedModel) {
+        dao[association.accessors.get]().then(function(associatedModel) {
           callback(null, associatedModel)
         })
       }
@@ -267,11 +267,11 @@ var handleResourceIndex = function(modelName, query, callback) {
   if (!!daoFactory) {
     daoFactory
       .findAll(where)
-      .success(function(entries) {
+      .then(function(entries) {
         entries = entries.map(function(entry) { return entry.values })
         this.handleSuccess(entries, callback)
       }.bind(this))
-      .error(function(err) {
+      .catch(function(err) {
         this.handleError(err, callback)
       }.bind(this))
   } else {
@@ -301,14 +301,14 @@ var handleResourceShow = function(modelName, identifier, callback) {
   if (!!daoFactory) {
     daoFactory
       .find({ where: { id: identifier }})
-      .success(function(entry) {
+      .then(function(entry) {
         if (!entry){
           this.handleSuccess({}, callback)
         }else{
           this.handleSuccess(entry.values, callback)
         }
       }.bind(this))
-      .error(function(err) {
+      .catch(function(err) {
         this.handleError(err, callback)
       }.bind(this))
   } else {
@@ -322,14 +322,14 @@ var handleResourceCreate = function(modelName, attributes, callback) {
   if (!!daoFactory) {
     daoFactory
       .create(attributes)
-      .success(function(entry) {
+      .then(function(entry) {
         if (!entry){
           this.handleSuccess({}, callback)
         }else{
           this.handleSuccess(entry.values, callback)
         }
       }.bind(this))
-      .error(function(err) {
+      .catch(function(err) {
         this.handleError(err, callback)
       }.bind(this))
   } else {
@@ -343,7 +343,7 @@ var handleResourceUpdate = function(modelName, identifier, attributes, callback)
   if (!!daoFactory) {
     daoFactory
       .find({ where: { id: identifier } })
-      .success(function(entry) {
+      .then(function(entry) {
         if (!entry){
           this.handleError("This object doesn't exists", callback)
         }else{
@@ -356,7 +356,7 @@ var handleResourceUpdate = function(modelName, identifier, attributes, callback)
           }.bind(this))
         }
       }.bind(this))
-      .error(function(err) {
+      .catch(function(err) {
         this.handleError(err, callback)
       }.bind(this))
   } else {
@@ -370,7 +370,7 @@ var handleResourceDelete = function(modelName, identifier, callback) {
   if (!!daoFactory) {
     daoFactory
       .find({ where: { id: identifier }})
-      .success(function(entry) {
+      .then(function(entry) {
 
         if (!entry){
           this.handleError("This object doesn't exists", callback)
@@ -386,7 +386,7 @@ var handleResourceDelete = function(modelName, identifier, callback) {
             }.bind(this))
         }
       }.bind(this))
-      .error(function(err) {
+      .catch(function(err) {
         this.handleError(err, callback)
       }.bind(this))
   } else {
@@ -401,12 +401,12 @@ var handleResourceIndexAssociation = function(modelName,identifier,associatedMod
   if (!!association){
     daoFactory
       .find(identifier)
-      .success(function(entry) {
+      .then(function(entry) {
         if (!entry) {
           this.handleSuccess({}, callback)
         } else {
           entry[association.accessors.get]()
-            .success(function(entries){
+            .then(function(entries){
               // depending on the type of the association,
               // entries will be either an array or a single instance.
               if (Array.isArray(entries)) {
@@ -419,7 +419,7 @@ var handleResourceIndexAssociation = function(modelName,identifier,associatedMod
             }.bind(this))
         }
       }.bind(this))
-      .error(function(err) {
+      .catch(function(err) {
         this.handleError(err, callback)
       }.bind(this))
   } else {
@@ -435,31 +435,31 @@ var handleResourceDeleteAssociation = function(modelName,identifier,associatedMo
   if (!!associatedDaoFactory) {
     daoFactory
       .find({ where: { id: identifier }})
-      .success(function(parent) {
+      .then(function(parent) {
         associatedDaoFactory
           .find({ where: { id: associatedIdentifier }})
-            .success(function(child) {
+            .then(function(child) {
               if (association.associationType === 'BelongsTo') {
-                parent[association.accessors.set](null).success(function(){
+                parent[association.accessors.set](null).then(function(){
                   this.handleSuccess({}, callback)
                 }.bind(this))
-                .error(function(err){
+                .catch(function(err){
                   this.handleError(err, callback)
                 }.bind(this))
               } else {
-                parent[association.accessors.remove](child).success(function(){
+                parent[association.accessors.remove](child).then(function(){
                   this.handleSuccess({}, callback)
                 }.bind(this))
-                .error(function(err){
+                .catch(function(err){
                   this.handleError(err, callback)
                 }.bind(this))
               }
           }.bind(this))
-          .error(function(err) {
+          .catch(function(err) {
             this.handleError(err, callback)
           }.bind(this))
       }.bind(this))
-      .error(function(err) {
+      .catch(function(err) {
         this.handleError(err, callback)
       }.bind(this))
   } else {

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -83,7 +83,7 @@ describe('Router', function() {
         it('creates a new photo instance', function(done) {
           var self = this
 
-          this.Photo.count().success(function(photoCountBefore) {
+          this.Photo.count().then(function(photoCountBefore) {
             self.router.handleRequest({
               method: 'POST',
               path: '/api/photos',
@@ -91,7 +91,7 @@ describe('Router', function() {
                 name: 'my lovely photo'
               }
             }, function() {
-              self.Photo.count().success(function(photoCountAfter) {
+              self.Photo.count().then(function(photoCountAfter) {
                 expect(photoCountAfter).to.equal(photoCountBefore + 1)
                 done()
               })
@@ -124,8 +124,8 @@ describe('Router', function() {
       before(function(done) {
         var self = this
 
-        this.Photo.destroy().success(function() {
-          self.Photo.create({ name: 'a lovely photo' }).success(function(photo) {
+        this.Photo.destroy().then(function() {
+          self.Photo.create({ name: 'a lovely photo' }).then(function(photo) {
             self.photoId = photo.id
             done()
           })
@@ -163,7 +163,7 @@ describe('Router', function() {
             path:   '/api/photos/' + this.photoId,
             body:   { name: 'another name' }
           }, function(response) {
-            self.Photo.find(self.photoId).success(function(photo) {
+            self.Photo.find(self.photoId).then(function(photo) {
               expect(response.data.name).to.equal('another name')
               expect(photo.name).to.equal('another name')
               done()
@@ -181,7 +181,7 @@ describe('Router', function() {
             path:   '/api/photos/' + this.photoId,
             body:   { name: 'yet another name' }
           }, function(response) {
-            self.Photo.find(self.photoId).success(function(photo) {
+            self.Photo.find(self.photoId).then(function(photo) {
               expect(response.data.name).to.equal('yet another name')
               expect(photo.name).to.equal('yet another name')
               done()
@@ -194,7 +194,7 @@ describe('Router', function() {
         it('deletes a resource', function(done) {
           var self = this
 
-          this.Photo.count().success(function(photoCountBefore) {
+          this.Photo.count().then(function(photoCountBefore) {
             self.router.handleRequest({
               method: 'DELETE',
               path:   '/api/photos/' + self.photoId,
@@ -202,7 +202,7 @@ describe('Router', function() {
             }, function(response) {
               expect(response.status).to.equal('success')
 
-              self.Photo.count().success(function(photoCountAfter) {
+              self.Photo.count().then(function(photoCountAfter) {
                 expect(photoCountAfter).to.equal(photoCountBefore - 1)
                 done()
               })
@@ -263,7 +263,7 @@ describe('Router', function() {
             }, function(response) {
               expect(response.status).to.equal('success')
 
-              self.photo.reload().success(function(photo) {
+              self.photo.reload().then(function(photo) {
                 expect(photo.photographerId).to.not.be.ok()
                 done()
               })
@@ -308,7 +308,7 @@ describe('Router', function() {
             }, function(response) {
               expect(response.status).to.equal('success')
 
-              self.photo.reload().success(function(photo) {
+              self.photo.reload().then(function(photo) {
                 expect(photo.photographerId).to.not.be.ok()
                 done()
               })


### PR DESCRIPTION
Eliminates the nag message from sequelize 2.0.4.

````
success|ok() is deprecated and will be removed in 2.1, please use promise-style instead.
failure|fail|error() is deprecated  and will be removed in 2.1, please use promise-style instead.
````