### PR TITLE
Changed .get() to .values to supress deprecated warning

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -268,7 +268,7 @@ var handleResourceIndex = function(modelName, query, callback) {
     daoFactory
       .findAll(where)
       .then(function(entries) {
-        entries = entries.map(function(entry) { return entry.values })
+        entries = entries.map(function(entry) { return entry.get() })
         this.handleSuccess(entries, callback)
       }.bind(this))
       .catch(function(err) {
@@ -305,7 +305,7 @@ var handleResourceShow = function(modelName, identifier, callback) {
         if (!entry){
           this.handleSuccess({}, callback)
         }else{
-          this.handleSuccess(entry.values, callback)
+          this.handleSuccess(entry.get(), callback)
         }
       }.bind(this))
       .catch(function(err) {
@@ -326,7 +326,7 @@ var handleResourceCreate = function(modelName, attributes, callback) {
         if (!entry){
           this.handleSuccess({}, callback)
         }else{
-          this.handleSuccess(entry.values, callback)
+          this.handleSuccess(entry.get(), callback)
         }
       }.bind(this))
       .catch(function(err) {
@@ -351,7 +351,7 @@ var handleResourceUpdate = function(modelName, identifier, attributes, callback)
             if (err) {
               this.handleError(err, callback)
             } else {
-              this.handleSuccess(entry.values, callback)
+              this.handleSuccess(entry.get(), callback)
             }
           }.bind(this))
         }
@@ -410,9 +410,9 @@ var handleResourceIndexAssociation = function(modelName,identifier,associatedMod
               // depending on the type of the association,
               // entries will be either an array or a single instance.
               if (Array.isArray(entries)) {
-                entries = entries.map(function(entry) { return entry.values })
+                entries = entries.map(function(entry) { return entry.get() })
               } else {
-                entries = entries.values
+                entries = entries.get()
               }
 
               this.handleSuccess(entries, callback)


### PR DESCRIPTION
Sequelize 2.0 warns:

````
Using .values has been deprecated. Please use .get() instead
````

Changed .values to .get(), passes all tests in 1.7. 

Fails in 2.0 due to unrelated issues, will work to fix those too in a future PR.